### PR TITLE
Fix test

### DIFF
--- a/tests/cmd/execute_command.py
+++ b/tests/cmd/execute_command.py
@@ -94,15 +94,15 @@ async def _unittest_basic(_context: tuple[Runner, tuple[Remote, Remote]]) -> Non
     assert await run("10-12", "restart", "--timeout=3") == (
         0,
         {
-            "10": {"status": 0},
-            "11": {"status": 0},
+            "10": {"output": '', "status": 0},
+            "11": {"output": '', "status": 0},
         },
     )
     assert await run("10-12", "111", "COMMAND ARGUMENT", "--timeout=3") == (
         0,
         {
-            "10": {"status": 0},
-            "11": {"status": 0},
+            "10": {"output": '', "status": 0},
+            "11": {"output": '', "status": 0},
         },
     )
     assert (
@@ -122,15 +122,15 @@ async def _unittest_basic(_context: tuple[Runner, tuple[Remote, Remote]]) -> Non
     assert await run("10-12", "restart", "--timeout=3") == (
         EXIT_CODE_UNSUCCESSFUL,
         {
-            "10": {"status": 100},
-            "11": {"status": 200},
+            "10": {"output": '', "status": 100},
+            "11": {"output": '', "status": 200},
         },
     )
     assert await run("10-12", "123", "--expect=100,200", "--timeout=3") == (
         0,
         {
-            "10": {"status": 100},
-            "11": {"status": 200},
+            "10": {"output": '', "status": 100},
+            "11": {"output": '', "status": 200},
         },
     )
     assert remote_10.last_request and remote_10.last_request.command == 123
@@ -143,14 +143,14 @@ async def _unittest_basic(_context: tuple[Runner, tuple[Remote, Remote]]) -> Non
         EXIT_CODE_UNSUCCESSFUL,
         {
             "10": None,
-            "11": {"status": 0},
+            "11": {"output": '', "status": 0},
         },
     )
     assert await run("10-12", "123", "--expect") == (
         0,
         {
             "10": None,
-            "11": {"status": 0},
+            "11": {"output": '', "status": 0},
         },
     )
 
@@ -158,7 +158,7 @@ async def _unittest_basic(_context: tuple[Runner, tuple[Remote, Remote]]) -> Non
     remote_11.next_response = ExecuteCommand_1.Response(status=210)
     assert await run("11", "123", "FOO BAR", "--timeout=3") == (
         EXIT_CODE_UNSUCCESSFUL,
-        {"status": 210},
+        {"output": '', "status": 210},
     )
     assert (
         remote_11.last_request
@@ -167,7 +167,7 @@ async def _unittest_basic(_context: tuple[Runner, tuple[Remote, Remote]]) -> Non
     )
     assert await run("11", "222", "--timeout=3", "--expect=0..256") == (
         0,
-        {"status": 210},
+        {"output": '', "status": 210},
     )
     assert (
         remote_11.last_request


### PR DESCRIPTION
This fixes the failing unit test `tests/cmd/execute_command.py`.

The issue arose due to this implemented in `public_regulated_data_types`:

https://github.com/OpenCyphal/public_regulated_data_types/commit/ec2788372559c8e1cf7b36f528d81074e523303e